### PR TITLE
Fix building on FreeBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,8 @@ case $uos in
   *freebsd* | *dragonfly* ) 
     myos="freebsd"
     LINK_FLAGS="$LINK_FLAGS -lm"
+     CC="clang"
+    LINKER="clang"
     ;;
   *openbsd* )
     myos="openbsd" 

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ case $uos in
   *freebsd* | *dragonfly* ) 
     myos="freebsd"
     LINK_FLAGS="$LINK_FLAGS -lm"
-     CC="clang"
+    CC="clang"
     LINKER="clang"
     ;;
   *openbsd* )


### PR DESCRIPTION
Set default compiler to clang, as well as the linker, to allow csources to build on FreeBSD. By default, it won't build on recent BSD, which only has clang.