### PR TITLE
make it works in Android's Debian

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -114,7 +114,7 @@ case $ucpu in
     mycpu="powerpc" ;;
   *mips* ) 
     mycpu="mips" ;;
-  *arm*|*armv6l* )
+  *arm*|*armv6l*|*aarch* )
     mycpu="arm" ;;
   *) 
     echo "Error: unknown processor: $ucpu"


### PR DESCRIPTION
Android's uname command show "aarch" or "aarch64", not "arm".