### PR TITLE
Ignore build object files *.o & *.obj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# ignore build object files
+*.o
+*.obj


### PR DESCRIPTION
Otherwise once called ./build.sh repo will be marked as dirty, which may be a
problem when using csources as submodule of Nim main repo.

This change is somehow related to: https://github.com/Araq/Nim/pull/2649