### PR TITLE
build.sh: Use getconf for bitness detection on Linux/sparc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -139,8 +139,12 @@ case $ucpu in
     mycpu="amd64" ;;
   *sparc*|*sun* )
     mycpu="sparc"
-    if [ "$(isainfo -b)" = "64" ]; then
-      mycpu="sparc64"
+    if [ "$myos" = "linux" ] ; then
+	if [ "$(getconf LONG_BIT)" = "64" ]; then
+	    mycpu="sparc64"
+	elif [ "$(isainfo -b)" = "64" ]; then
+	    mycpu="sparc64"
+	fi
     fi
     ;;
   *ppc64le* )


### PR DESCRIPTION
The isainfo utility is specific to Solaris and not available on Linux/sparc. While getconf exists on Solaris as well, it does not always seem to match the bitness reported by isainfo on Solaris and isainfo should herefore be preferred on Solaris.